### PR TITLE
Improved control over concurrent running checks.

### DIFF
--- a/aws_quota/check/elb.py
+++ b/aws_quota/check/elb.py
@@ -199,7 +199,7 @@ class TargetsPerAZPerNetworkLoadBalancerCountCheck(InstanceQuotaCheck):
                     else:
                         if tg['AvailabilityZone'] not in counts:
                             counts[tg['AvailabilityZone']] = 0
-                        tg['AvailabilityZone'] += 1
+                        counts[tg['AvailabilityZone']] += 1
             if not counts:
                 return all
             else:

--- a/aws_quota/check/iam.py
+++ b/aws_quota/check/iam.py
@@ -114,6 +114,9 @@ class AttachedPolicyPerUserCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
         else:
@@ -144,6 +147,9 @@ class GroupsPerUserCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
         else:
@@ -173,7 +179,9 @@ class ManagedPolicyLengthCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
-        # Managed policies are global but quota is available only in us-east-1
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             paginator = get_client(session, 'iam').get_paginator('list_policies')
             policies = list((chunk for page in paginator.paginate(Scope='All', PaginationConfig={'PageSize': 100}) for chunk in page['Policies']))
@@ -205,6 +213,9 @@ class AccessKeysPerUserCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
         else:
@@ -234,6 +245,9 @@ class AttachedPolicyPerGroupCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             return [user['GroupName'] for user in session.client('iam').list_groups()['Groups']]
         else:
@@ -260,6 +274,9 @@ class AttachedPolicyPerRoleCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # The IAM is a global service. It can be accessed from any region and in any region the results are exactly the same.
+        # However, only in us-east-1 the Service Quota returns the limit value for IAM. In all other regions the quota value
+        # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             return [user['RoleName'] for user in session.client('iam').list_roles()['Roles']]
         else:

--- a/aws_quota/check/iam.py
+++ b/aws_quota/check/iam.py
@@ -1,8 +1,22 @@
 from aws_quota.exceptions import InstanceWithIdentifierNotFound
 import typing
-
+import re
 import boto3
 from .quota_check import InstanceQuotaCheck, QuotaCheck, QuotaScope
+from aws_quota import threadsafecache
+from aws_quota.utils import get_client
+import json
+
+
+@threadsafecache.run_once_cache
+def get_account_summary(client):
+    return client.get_account_summary()['SummaryMap']
+
+
+@threadsafecache.run_once_cache
+def get_users(client):
+    paginator = client.get_paginator('list_users')
+    return list((chunk for page in paginator.paginate(PaginationConfig={'PageSize': 100}) for chunk in page['Users']))
 
 
 class GroupCountCheck(QuotaCheck):
@@ -15,11 +29,11 @@ class GroupCountCheck(QuotaCheck):
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['GroupsQuota']
+        return get_account_summary(self.get_client(self.service_code))['GroupsQuota']
 
     @property
     def current(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['Groups']
+        return get_account_summary(self.get_client(self.service_code))['Groups']
 
 
 class UsersCountCheck(QuotaCheck):
@@ -32,11 +46,11 @@ class UsersCountCheck(QuotaCheck):
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['UsersQuota']
+        return get_account_summary(self.get_client(self.service_code))['UsersQuota']
 
     @property
     def current(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['Users']
+        return get_account_summary(self.get_client(self.service_code))['Users']
 
 
 class PolicyCountCheck(QuotaCheck):
@@ -49,11 +63,11 @@ class PolicyCountCheck(QuotaCheck):
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['PoliciesQuota']
+        return get_account_summary(self.get_client(self.service_code))['PoliciesQuota']
 
     @property
     def current(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['Policies']
+        return get_account_summary(self.get_client(self.service_code))['Policies']
 
 
 class PolicyVersionCountCheck(QuotaCheck):
@@ -65,11 +79,11 @@ class PolicyVersionCountCheck(QuotaCheck):
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['PolicyVersionsInUseQuota']
+        return get_account_summary(self.get_client(self.service_code))['PolicyVersionsInUseQuota']
 
     @property
     def current(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['PolicyVersionsInUse']
+        return get_account_summary(self.get_client(self.service_code))['PolicyVersionsInUse']
 
 
 class ServerCertificateCountCheck(QuotaCheck):
@@ -82,11 +96,11 @@ class ServerCertificateCountCheck(QuotaCheck):
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['ServerCertificatesQuota']
+        return get_account_summary(self.get_client(self.service_code))['ServerCertificatesQuota']
 
     @property
     def current(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['ServerCertificates']
+        return get_account_summary(self.get_client(self.service_code))['ServerCertificates']
 
 
 class AttachedPolicyPerUserCheck(InstanceQuotaCheck):
@@ -96,21 +110,119 @@ class AttachedPolicyPerUserCheck(InstanceQuotaCheck):
     service_code = 'iam'
     quota_code = 'L-4019AD8B'
     used_services = [service_code]
+    concurrency = 32
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
-        return [user['UserName'] for user in session.client('iam').list_users()['Users']]
+        if session.region_name == 'us-east-1':
+            return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
+        else:
+            return []
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['AttachedPoliciesPerUserQuota']
+        return get_account_summary(self.get_client(self.service_code))['AttachedPoliciesPerUserQuota']
 
     @property
     def current(self):
         try:
-            return len(self.get_client(self.service_code).list_user_policies(UserName=self.instance_id)['PolicyNames'])
+            paginator = self.get_client(self.service_code).get_paginator('list_user_policies')
+            policy_names = list((chunk for page in paginator.paginate(UserName=self.instance_id, PaginationConfig={'PageSize': 100}) for chunk in page['PolicyNames']))
+            return len(policy_names)
         except self.get_client(self.service_code).exceptions.NoSuchEntityException as e:
             raise InstanceWithIdentifierNotFound(self) from e
+
+
+class GroupsPerUserCheck(InstanceQuotaCheck):
+    key = "iam_groups_per_user"
+    description = "IAM groups per user"
+    instance_id = "User Name"
+    service_code = 'iam'
+    quota_code = 'L-7A1621EC'
+    used_services = [service_code]
+    concurrency = 32
+
+    @staticmethod
+    def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        if session.region_name == 'us-east-1':
+            return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
+        else:
+            return []
+
+    @property
+    def maximum(self):
+        return get_account_summary(self.get_client(self.service_code))['GroupsPerUserQuota']
+
+    @property
+    def current(self):
+        try:
+            paginator = self.get_client(self.service_code).get_paginator('list_groups_for_user')
+            groups = list((chunk for page in paginator.paginate(UserName=self.instance_id, PaginationConfig={'PageSize': 100}) for chunk in page['Groups']))
+            return len(groups)
+        except self.get_client(self.service_code).exceptions.NoSuchEntityException as e:
+            raise InstanceWithIdentifierNotFound(self) from e
+
+
+class ManagedPolicyLengthCheck(InstanceQuotaCheck):
+    key = "iam_managed_policy_length"
+    description = "Managed policy length"
+    instance_id = "(Policy ARN, Version Id)"
+    service_code = 'iam'
+    quota_code = 'L-ED111B8C'
+    used_services = [service_code]
+
+    @staticmethod
+    def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        # Managed policies are global but quota is available only in us-east-1
+        if session.region_name == 'us-east-1':
+            paginator = get_client(session, 'iam').get_paginator('list_policies')
+            policies = list((chunk for page in paginator.paginate(Scope='All', PaginationConfig={'PageSize': 100}) for chunk in page['Policies']))
+            return [(p['Arn'], p['DefaultVersionId']) for p in policies]
+        else:
+            return []
+
+    @property
+    def current(self):
+        try:
+            arn, version = self.instance_id
+            policy = self.get_client(self.service_code).get_policy_version(PolicyArn=arn, VersionId=version)
+            policy_json = json.dumps(policy['PolicyVersion']['Document'])
+            # IAM does not count white space when calculating the size of a policy against this quota,
+            # see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length
+            return len(re.sub(r"\s", "", policy_json))
+        except self.get_client(self.service_code).exceptions.NoSuchEntityException as e:
+            raise InstanceWithIdentifierNotFound(self) from e
+
+
+class AccessKeysPerUserCheck(InstanceQuotaCheck):
+    key = "iam_access_keys_per_user"
+    description = "Access keys per user"
+    instance_id = "User Name"
+    service_code = 'iam'
+    quota_code = 'L-8758042E'
+    used_services = [service_code]
+    concurrency = 32
+
+    @staticmethod
+    def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
+        if session.region_name == 'us-east-1':
+            return [user['UserName'] for user in get_users(get_client(session, 'iam'))]
+        else:
+            return []
+
+    @property
+    def maximum(self):
+        return get_account_summary(self.get_client(self.service_code))['AccessKeysPerUserQuota']
+
+    @property
+    def current(self):
+        try:
+            paginator = self.get_client(self.service_code).get_paginator('list_access_keys')
+            access_keys_metadatas = list((chunk for page in paginator.paginate(UserName=self.instance_id, PaginationConfig={'PageSize': 100}) for chunk in page['AccessKeyMetadata']))
+            return len(access_keys_metadatas)
+        except self.get_client(self.service_code).exceptions.NoSuchEntityException as e:
+            raise InstanceWithIdentifierNotFound(self) from e
+
 
 class AttachedPolicyPerGroupCheck(InstanceQuotaCheck):
     key = "iam_attached_policy_per_group"
@@ -122,11 +234,14 @@ class AttachedPolicyPerGroupCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
-        return [user['GroupName'] for user in session.client('iam').list_groups()['Groups']]
+        if session.region_name == 'us-east-1':
+            return [user['GroupName'] for user in session.client('iam').list_groups()['Groups']]
+        else:
+            return []
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['AttachedPoliciesPerGroupQuota']
+        return get_account_summary(self.get_client(self.service_code))['AttachedPoliciesPerGroupQuota']
 
     @property
     def current(self):
@@ -145,11 +260,14 @@ class AttachedPolicyPerRoleCheck(InstanceQuotaCheck):
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
-        return [user['RoleName'] for user in session.client('iam').list_roles()['Roles']]
+        if session.region_name == 'us-east-1':
+            return [user['RoleName'] for user in session.client('iam').list_roles()['Roles']]
+        else:
+            return []
 
     @property
     def maximum(self):
-        return self.get_client(self.service_code).get_account_summary()['SummaryMap']['AttachedPoliciesPerRoleQuota']
+        return get_account_summary(self.get_client(self.service_code))['AttachedPoliciesPerRoleQuota']
 
     @property
     def current(self):

--- a/aws_quota/check/iam.py
+++ b/aws_quota/check/iam.py
@@ -184,7 +184,7 @@ class ManagedPolicyLengthCheck(InstanceQuotaCheck):
         # is missing for IAM. The us-east-1 is the "main" region in some sense.
         if session.region_name == 'us-east-1':
             paginator = get_client(session, 'iam').get_paginator('list_policies')
-            policies = list((chunk for page in paginator.paginate(Scope='All', PaginationConfig={'PageSize': 100}) for chunk in page['Policies']))
+            policies = list((chunk for page in paginator.paginate(Scope='Local', PaginationConfig={'PageSize': 100}) for chunk in page['Policies']))
             return [(p['Arn'], p['DefaultVersionId']) for p in policies]
         else:
             return []


### PR DESCRIPTION
Now checks have a "concurrency" field which specifies
how many instances can run at the same time. This is to
avoid exceeding AWS API query rate limits.

Added checks:
 - ELB:
   - Targets per Availability Zone per Network Load Balancer L-B211E961
  - IAM:
    - Access keys per user L-8758042E
    - IAM groups per user L-7A1621EC
    - Managed policy length L-ED111B8C